### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,24 +129,25 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to items_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <%= image_tag item.image, class: "item-img" %>
+ 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+            <div class='sold-out'>
+             <span>Sold Out!!</span>
+            </div>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,11 +155,13 @@
           </div>
         </div>
         <% end %>
-      </li>
+       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+     <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,6 +179,7 @@
         </div>
         <% end %>
       </li>
+     <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -136,9 +136,11 @@
           <%= image_tag item.image, class: "item-img" %>
  
           <%# 商品が売れていればsold outを表示しましょう %>
+           <% if item.sold_out? %>
             <div class='sold-out'>
              <span>Sold Out!!</span>
             </div>
+           <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,22 +128,19 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to items_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
  
-          <%# 商品が売れていればsold outを表示しましょう %>
            <% if item.sold_out? %>
             <div class='sold-out'>
              <span>Sold Out!!</span>
             </div>
            <% end %>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
+        
         <div class='item-info'>
           <h3 class='item-name'>
             <%= item.name %>
@@ -159,10 +156,7 @@
         <% end %>
        </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -182,8 +176,6 @@
         <% end %>
       </li>
      <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to items_path(item) do %>
+        <%= link_to '#' do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
  
@@ -140,7 +140,7 @@
             </div>
            <% end %>
         </div>
-        
+
         <div class='item-info'>
           <h3 class='item-name'>
             <%= item.name %>


### PR DESCRIPTION
# What
トップページに出品（保存）した商品一覧を表示。

# Why
出品した商品や売れた商品の表示をするため。

# 添付資料
・商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/eba724efcf8fd7c0a5a99dca5504bf5b

・商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/4b2fd3a7ab0f2f632fc08ba5212ab1b4

以上です。
お手数ですがよろしくおねがします！